### PR TITLE
(x) #ORCOMP-301 Added optional parameter excludeFileNamePatterns to CreateSupportPackageAsync method in order to exclude files types by a pattern (for instance executable files like *.dll or *.exe)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 
 Geert van Horrik <geert@catenalogic.com>
 Maksim Khomutov <mkhomutov@gmail.com>
+Igr Alexánder Fernández Saúco <alexander.fernandez.sauco@gmail.com>

--- a/src/Orc.SupportPackage.Example/SupportPackage/Providers/CustomSupportPackageProvider.cs
+++ b/src/Orc.SupportPackage.Example/SupportPackage/Providers/CustomSupportPackageProvider.cs
@@ -7,9 +7,11 @@
 
 namespace Orc.SupportPackage.Example
 {
-    using System.IO;
     using System.Threading.Tasks;
     using Catel;
+    using Catel.IoC;
+    using Catel.Windows.Interactivity;
+    using FileSystem;
 
     public class CustomSupportPackageProvider : SupportPackageProviderBase
     {
@@ -18,8 +20,14 @@ namespace Orc.SupportPackage.Example
             Argument.IsNotNull(() => supportPackageContext);
 
             var file = supportPackageContext.GetFile("testfile.txt");
-            
-            File.WriteAllText(file, "custom suppport package contents");
+
+            var fileService = this.GetDependencyResolver().Resolve<IFileService>();
+
+            fileService.WriteAllText(file, "custom suppport package contents");
+
+            fileService.WriteAllText(supportPackageContext.GetFile("testfile.exe"), "An exe file as custom package contents");
+            fileService.WriteAllText(supportPackageContext.GetFile("testfile.dll"), "An dll file as custom package contents");
+            fileService.WriteAllText(supportPackageContext.GetFile("testfile.exe.config"), "An config file as custom package contents");
         }
     }
 }

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Models/SupportPackageFileType.cs
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Models/SupportPackageFileType.cs
@@ -1,0 +1,35 @@
+// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="SupportPackageFileType.cs" company="WildGums">
+//   Copyright (c) 2008 - 2017 WildGums. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Orc.SupportPackage
+{
+    using System.Linq;
+    using Catel;
+    using Catel.Data;
+    using Catel.Fody;
+
+    public class SupportPackageFileType : ModelBase
+    {
+        public SupportPackageFileType(string title, string[] fileNamePatterns, bool includeInSupportPackage = true)
+        {
+            Argument.IsNotNullOrWhitespace(() => title);
+            Argument.IsNotNullOrEmptyArray(() => fileNamePatterns);
+
+            string patterns = fileNamePatterns.Aggregate("(", (current, fileExtension) => current + fileExtension + " | ").TrimEnd('|', ' ') + ")";
+
+            Title = title + " " + patterns;
+            FileNamePatterns = fileNamePatterns;
+            IncludeInSupportPackage = includeInSupportPackage;
+        }
+
+        public string Title { get; }
+
+        [NoWeaving]
+        public string[] FileNamePatterns { get; }
+
+        public bool IncludeInSupportPackage { get; set; } 
+    }
+}

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Orc.SupportPackage.Xaml.Shared.projitems
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Orc.SupportPackage.Xaml.Shared.projitems
@@ -10,11 +10,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)..\..\SolutionAssemblyInfo.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)..\..\GlobalSuppressions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)..\..\GlobalSuppressions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModuleInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Models\SupportPackageFileType.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\SupportPackageViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Views\SupportPackageWindow.xaml.cs">
       <DependentUpon>SupportPackageWindow.xaml</DependentUpon>
@@ -25,5 +26,8 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Models\" />
   </ItemGroup>
 </Project>

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.NET40.Designer.cs
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.NET40.Designer.cs
@@ -122,5 +122,59 @@ namespace Orc.SupportPackage.Properties {
                 return ResourceManager.GetString("SupportPackage_SupportPackageFiles", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configuration files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ConfigurationFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ConfigurationFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Executable files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ExecutableFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ExecutableFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ImageFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ImageFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Log files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_LogFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_LogFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to System information.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_SystemInformation_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_SystemInformation_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_TextFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_TextFiles_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.NET45.Designer.cs
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.NET45.Designer.cs
@@ -122,5 +122,59 @@ namespace Orc.SupportPackage.Properties {
                 return ResourceManager.GetString("SupportPackage_SupportPackageFiles", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configuration files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ConfigurationFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ConfigurationFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Executable files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ExecutableFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ExecutableFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ImageFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ImageFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Log files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_LogFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_LogFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to System information.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_SystemInformation_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_SystemInformation_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_TextFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_TextFiles_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.NET46.Designer.cs
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.NET46.Designer.cs
@@ -122,5 +122,59 @@ namespace Orc.SupportPackage.Xaml.Properties {
                 return ResourceManager.GetString("SupportPackage_SupportPackageFiles", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Configuration files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ConfigurationFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ConfigurationFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Executable files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ExecutableFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ExecutableFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_ImageFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_ImageFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Log files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_LogFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_LogFiles_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to System information.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_SystemInformation_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_SystemInformation_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text files.
+        /// </summary>
+        internal static string SupportPackage_SupportPackageFileType_TextFiles_Title {
+            get {
+                return ResourceManager.GetString("SupportPackage_SupportPackageFileType_TextFiles_Title", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.de.resx
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.de.resx
@@ -138,4 +138,22 @@
   <data name="SupportPackage_SupportPackageFiles" xml:space="preserve">
     <value>Support package files</value>
   </data>
+  <data name="SupportPackage_SupportPackageFileType_SystemInformation_Title" xml:space="preserve">
+    <value>System information</value>
+</data>
+  <data name="SupportPackage_SupportPackageFileType_ExecutableFiles_Title" xml:space="preserve">
+    <value>Executable files</value>
+</data>
+  <data name="SupportPackage_SupportPackageFileType_ConfigurationFiles_Title" xml:space="preserve">
+    <value>Configuration files</value>
+</data>
+  <data name="SupportPackage_SupportPackageFileType_LogFiles_Title" xml:space="preserve">
+    <value>Log files</value>
+</data>
+  <data name="SupportPackage_SupportPackageFileType_TextFiles_Title" xml:space="preserve">
+    <value>Text files</value>
+</data>
+  <data name="SupportPackage_SupportPackageFileType_ImageFiles_Title" xml:space="preserve">
+    <value>Image files</value>
+</data>
 </root>

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.es.resx
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.es.resx
@@ -138,4 +138,22 @@
   <data name="SupportPackage_SupportPackageFiles" xml:space="preserve">
     <value>Support package files</value>
   </data>
+  <data name="SupportPackage_SupportPackageFileType_SystemInformation_Title" xml:space="preserve">
+    <value>System information</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ExecutableFiles_Title" xml:space="preserve">
+      <value>Executable files</value>
+  </data>
+    <data name="SupportPackage_SupportPackageFileType_ConfigurationFiles_Title" xml:space="preserve">
+      <value>Configuration files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_LogFiles_Title" xml:space="preserve">
+      <value>Log files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_TextFiles_Title" xml:space="preserve">
+      <value>Text files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ImageFiles_Title" xml:space="preserve">
+      <value>Image files</value>
+  </data>
 </root>

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.fr.resx
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.fr.resx
@@ -138,4 +138,22 @@
   <data name="SupportPackage_SupportPackageFiles" xml:space="preserve">
     <value>Support package files</value>
   </data>
+  <data name="SupportPackage_SupportPackageFileType_SystemInformation_Title" xml:space="preserve">
+    <value>System information</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ExecutableFiles_Title" xml:space="preserve">
+      <value>Executable files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ConfigurationFiles_Title" xml:space="preserve">
+      <value>Configuration files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_LogFiles_Title" xml:space="preserve">
+      <value>Log files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_TextFiles_Title" xml:space="preserve">
+      <value>Text files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ImageFiles_Title" xml:space="preserve">
+      <value>Image files</value>
+  </data>
 </root>

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.nl.resx
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.nl.resx
@@ -138,4 +138,22 @@
   <data name="SupportPackage_SupportPackageFiles" xml:space="preserve">
     <value>Ondersteuningspakket documenten</value>
   </data>
+  <data name="SupportPackage_SupportPackageFileType_SystemInformation_Title" xml:space="preserve">
+    <value>System information</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ExecutableFiles_Title" xml:space="preserve">
+      <value>Executable files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ConfigurationFiles_Title" xml:space="preserve">
+      <value>Configuration files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_LogFiles_Title" xml:space="preserve">
+      <value>Log files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_TextFiles_Title" xml:space="preserve">
+      <value>Text files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ImageFiles_Title" xml:space="preserve">
+      <value>Image files</value>
+  </data>
 </root>

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.resx
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.resx
@@ -138,4 +138,22 @@
   <data name="SupportPackage_SupportPackageFiles" xml:space="preserve">
     <value>Support package files</value>
   </data>
+  <data name="SupportPackage_SupportPackageFileType_SystemInformation_Title" xml:space="preserve">
+    <value>System information</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ExecutableFiles_Title" xml:space="preserve">
+      <value>Executable files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ConfigurationFiles_Title" xml:space="preserve">
+      <value>Configuration files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_LogFiles_Title" xml:space="preserve">
+      <value>Log files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_TextFiles_Title" xml:space="preserve">
+      <value>Text files</value>
+  </data>
+  <data name="SupportPackage_SupportPackageFileType_ImageFiles_Title" xml:space="preserve">
+      <value>Image files</value>
+  </data>
 </root>

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.ru.resx
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Properties/Resources.ru.resx
@@ -138,4 +138,22 @@
   <data name="SupportPackage_SupportPackageFiles" xml:space="preserve">
     <value>Support package files</value>
   </data>
+  <data name="SupportPackage_SupportPackageFileType_SystemInformation_Title" xml:space="preserve">
+    <value>System information</value>
+  </data>
+    <data name="SupportPackage_SupportPackageFileType_ExecutableFiles_Title" xml:space="preserve">
+      <value>Executable files</value>
+  </data>
+    <data name="SupportPackage_SupportPackageFileType_ConfigurationFiles_Title" xml:space="preserve">
+      <value>Configuration files</value>
+  </data>
+    <data name="SupportPackage_SupportPackageFileType_LogFiles_Title" xml:space="preserve">
+      <value>Log files</value>
+  </data>
+    <data name="SupportPackage_SupportPackageFileType_TextFiles_Title" xml:space="preserve">
+      <value>Text files</value>
+  </data>
+    <data name="SupportPackage_SupportPackageFileType_ImageFiles_Title" xml:space="preserve">
+      <value>Image files</value>
+  </data>
 </root>

--- a/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Views/SupportPackageWindow.xaml
+++ b/src/Orc.SupportPackage.Xaml/Orc.SupportPackage.Xaml.Shared/Views/SupportPackageWindow.xaml
@@ -9,6 +9,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         
         <Grid.ColumnDefinitions>
@@ -23,10 +24,18 @@
             </StackPanel>
         </Label>
 
-        <Button Grid.Row="1" Grid.Column="0" Command="{Binding CreateSupportPackage}" 
-                Content="{catel:LanguageBinding SupportPackage_IUnderstandCreateSupportPackage}" Margin="6" Padding="4" />
+        <ItemsControl Grid.Row="1" ItemsSource="{Binding SupportPackageFileTypes}" IsEnabled="{Binding ElementName=CreateSupportPackageButton, Path=IsEnabled}">
+            <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                    <CheckBox IsChecked="{Binding IncludeInSupportPackage}" Content="{Binding Title}" />
+                </DataTemplate>
+            </ItemsControl.ItemTemplate>
+        </ItemsControl>
 
-        <Button Grid.Row="2" Grid.Column="0" Command="{Binding OpenDirectory}" 
+        <Button Grid.Row="2" Grid.Column="0" Command="{Binding CreateSupportPackage}" 
+                Content="{catel:LanguageBinding SupportPackage_IUnderstandCreateSupportPackage}" Margin="6" Padding="4" x:Name="CreateSupportPackageButton" />
+
+        <Button Grid.Row="3" Grid.Column="0" Command="{Binding OpenDirectory}" 
                 Content="{catel:LanguageBinding SupportPackage_OpenDirectory}" Margin="6" Padding="4" />
     </Grid>
     

--- a/src/Orc.SupportPackage/Orc.SupportPackage.Shared/Services/Interfaces/ISupportPackageService.cs
+++ b/src/Orc.SupportPackage/Orc.SupportPackage.Shared/Services/Interfaces/ISupportPackageService.cs
@@ -7,10 +7,13 @@
 
 namespace Orc.SupportPackage
 {
+    using System;
     using System.Threading.Tasks;
 
     public interface ISupportPackageService
     {
         Task<bool> CreateSupportPackageAsync(string zipFileName);
+
+        Task<bool> CreateSupportPackageAsync(string zipFileName, string[] excludeFileNamePatterns);
     }
 }


### PR DESCRIPTION
Fixes #ORCOMP-301

### Changes proposed in this pull request:

- Added optional parameter excludeFileNamePatterns to CreateSupportPackageAsync method in order to exclude files types by a pattern (for instance executable files like *.dll or *.exe)