### PR TITLE
(x) #ORCOMP-377 Support package custom paths checkbox does not get disabled

### DIFF
--- a/src/Orc.SupportPackage.Xaml/Views/SupportPackageWindow.xaml
+++ b/src/Orc.SupportPackage.Xaml/Views/SupportPackageWindow.xaml
@@ -11,16 +11,14 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
         
-        <Label Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
+        <Label Grid.Row="0" Grid.Column="0">
             <StackPanel>
                 <TextBlock Text="{catel:LanguageBinding SupportPackage_Explanation_01}" TextWrapping="Wrap" Margin="0,0,0,12" />
                 <TextBlock Text="{catel:LanguageBinding SupportPackage_Explanation_02}" TextWrapping="Wrap" Margin="0,0,0,12" />
@@ -28,32 +26,43 @@
             </StackPanel>
         </Label>
 
-        <ItemsControl Grid.Row="1" Grid.ColumnSpan="2" ItemsSource="{Binding SupportPackageFileSystemArtifacts}" IsEnabled="{Binding ElementName=CreateSupportPackageButton, Path=IsEnabled}">
+        <ItemsControl Grid.Row="1"  ItemsSource="{Binding SupportPackageFileSystemArtifacts}" IsEnabled="{Binding ElementName=CreateSupportPackageButton, Path=IsEnabled}">
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <CheckBox IsChecked="{Binding IncludeInSupportPackage}" Content="{Binding Title}" />
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
-
-        <CheckBox Grid.Row="2" Grid.Column="0" IsChecked="{Binding IncludeCustomPathsInSupportPackage}" Content="{catel:LanguageBinding SupportPackage_CustomPaths}" />
-        <ListBox Grid.Row="3" Grid.Column="0" ItemsSource="{Binding CustomPaths}" Height="200" IsEnabled="{Binding IncludeCustomPathsInSupportPackage}"  SelectionMode="Multiple">
-            <i:Interaction.Triggers>
-                <i:EventTrigger EventName="SelectionChanged">
-                    <catel:EventToCommand Command="{Binding SelectionChangedCommand}" DisableAssociatedObjectOnCannotExecute="False" PassEventArgsToCommand="True"/>
-                </i:EventTrigger>
-            </i:Interaction.Triggers>
-        </ListBox>
-        <StackPanel Grid.Row="3" Grid.Column="1" IsEnabled="{Binding IncludeCustomPathsInSupportPackage}">
-            <Button VerticalAlignment="Top" Content="{catel:LanguageBinding SupportPackage_AddDirectory}" Command="{Binding AddDirectoryCommand}"/>
-            <Button VerticalAlignment="Top" Content="{catel:LanguageBinding SupportPackage_AddFile}" Command="{Binding AddFileCommand}"/>
-            <Button VerticalAlignment="Top" Content="{catel:LanguageBinding SupportPackage_RemovePath}" Command="{Binding RemovePathCommand}"/>
+        <StackPanel Grid.Row="2" Grid.Column="0" IsEnabled="{Binding ElementName=CreateSupportPackageButton, Path=IsEnabled}">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <CheckBox Grid.Row="0" Grid.Column="0" IsChecked="{Binding IncludeCustomPathsInSupportPackage}" Content="{catel:LanguageBinding SupportPackage_CustomPaths}"/>
+                <ListBox Grid.Row="1" Grid.Column="0" ItemsSource="{Binding CustomPaths}" Height="200" IsEnabled="{Binding IncludeCustomPathsInSupportPackage}"  SelectionMode="Multiple">
+                    <i:Interaction.Triggers>
+                        <i:EventTrigger EventName="SelectionChanged">
+                            <catel:EventToCommand Command="{Binding SelectionChangedCommand}" DisableAssociatedObjectOnCannotExecute="False" PassEventArgsToCommand="True"/>
+                        </i:EventTrigger>
+                    </i:Interaction.Triggers>
+                </ListBox>
+                <StackPanel Grid.Row="1" Grid.Column="1" IsEnabled="{Binding IncludeCustomPathsInSupportPackage}">
+                    <Button VerticalAlignment="Top" Content="{catel:LanguageBinding SupportPackage_AddDirectory}" Command="{Binding AddDirectoryCommand}"/>
+                    <Button VerticalAlignment="Top" Content="{catel:LanguageBinding SupportPackage_AddFile}" Command="{Binding AddFileCommand}"/>
+                    <Button VerticalAlignment="Top" Content="{catel:LanguageBinding SupportPackage_RemovePath}" Command="{Binding RemovePathCommand}"/>
+                </StackPanel>
+            </Grid>
         </StackPanel>
-
-        <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Command="{Binding CreateSupportPackage}" 
+        <Button Grid.Row="3" Grid.Column="0" Grid.ColumnSpan="2" Command="{Binding CreateSupportPackage}" 
                 Content="{catel:LanguageBinding SupportPackage_IUnderstandCreateSupportPackage}" Margin="6" Padding="4" x:Name="CreateSupportPackageButton" />
 
-        <Button Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Command="{Binding OpenDirectory}" 
+        <Button Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Command="{Binding OpenDirectory}" 
                 Content="{catel:LanguageBinding SupportPackage_OpenDirectory}" Margin="6" Padding="4" />
     </Grid>
     


### PR DESCRIPTION
Fixes #ORCOMP-377

### Changes proposed in this pull request:

- Fixed support package custom paths checkbox does not get disabled
